### PR TITLE
Fix default name for simulators

### DIFF
--- a/app/src/androidTest/java/com/percy/espresso_java/metadata/MetadataTest.java
+++ b/app/src/androidTest/java/com/percy/espresso_java/metadata/MetadataTest.java
@@ -43,6 +43,11 @@ public class MetadataTest {
     }
 
     @Test
+    public void testDeviceName() {
+        assertEquals(metadata.deviceName(), Build.MANUFACTURER + " " + Build.MODEL);
+    }
+
+    @Test
     public void testPlatformVersion() {
         assertEquals(metadata.platformVersion(), Build.VERSION.RELEASE);
     }

--- a/espresso/src/main/java/io/percy/espresso/metadata/MetadataHelper.java
+++ b/espresso/src/main/java/io/percy/espresso/metadata/MetadataHelper.java
@@ -33,7 +33,7 @@ public class MetadataHelper {
     }
 
     public static String sanitizedString(String string) {
-        return string.replaceAll("[^ a-zA-Z0-9_+-]", "").trim();
+        return string.replaceAll("[^ a-zA-Z0-9()._+-]", "").trim();
     }
 
     public static String parseBufferReader(BufferedReader reader, String model) {
@@ -57,6 +57,6 @@ public class MetadataHelper {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-        return null;
+        return Build.MANUFACTURER + " " + Build.MODEL;
     }
 }


### PR DESCRIPTION
- device names can contain () and . so we don’t want to strip those.
- Since simulator are not available in CSV file, and if user doesn’t pass device name in options, post call will return 500. adding a default for it.