### PR TITLE
Fix: read UTF-16 LE devices.csv with the correct charset (PER-9567)

### DIFF
--- a/app/src/androidTest/java/com/percy/espresso_java/metadata/MetadataHelperTest.java
+++ b/app/src/androidTest/java/com/percy/espresso_java/metadata/MetadataHelperTest.java
@@ -21,6 +21,9 @@ public class MetadataHelperTest {
         assertEquals(MetadataHelper.sanitizedString("SM-12#3## "), "SM-123");
     }
 
+    // devices.csv is UTF-16 LE (with BOM). The assertions below are the device names
+    // as parsed with the correct charset, verified against the CSV contents.
+
     @Test
     public void testDeviceNameFromCSVSamsung() {
         // brand + marketing name
@@ -31,6 +34,17 @@ public class MetadataHelperTest {
     public void testDeviceNameFromCSVRedmi() {
         // marketing name
         assertEquals(MetadataHelper.deviceNameFromCSV("22041216UC"), "Redmi Note 11T Pro +");
+    }
+
+    @Test
+    public void testDeviceNameFromCSVPixel() {
+        // brand + marketing name (Google)
+        assertEquals(MetadataHelper.deviceNameFromCSV("Pixel 7"), "Google Pixel 7");
+    }
+
+    @Test
+    public void testDeviceNameFromCSVSamsungGalaxyS23() {
+        assertEquals(MetadataHelper.deviceNameFromCSV("SM-S918B"), "Samsung Galaxy S23 Ultra");
     }
 
     @Test

--- a/espresso/src/main/java/io/percy/espresso/metadata/MetadataHelper.java
+++ b/espresso/src/main/java/io/percy/espresso/metadata/MetadataHelper.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
 import io.percy.espresso.lib.Cache;
 
@@ -22,11 +23,18 @@ public class MetadataHelper {
         try
         {
             InputStream inputStream = Metadata.class.getResourceAsStream("/devices.csv");
-            BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream));
+            // The bundled devices.csv is encoded UTF-16 LE with a byte-order mark.
+            // Use the UTF-16 charset so the BOM selects the byte order and is stripped,
+            // instead of relying on the platform-default charset (UTF-8), which left
+            // interleaved NUL bytes and a stray BOM that only worked by accident.
+            BufferedReader bufferedReader = new BufferedReader(
+                new InputStreamReader(inputStream, StandardCharsets.UTF_16));
             String device = parseBufferReader(bufferedReader, model);
             if (device == null) {
                 URL url = new URL("https://storage.googleapis.com/play_public/supported_devices.csv");
-                BufferedReader bufferedReaderNew = new BufferedReader(new InputStreamReader(url.openStream()));
+                // The remote Google Play devices list is UTF-8; read it explicitly.
+                BufferedReader bufferedReaderNew = new BufferedReader(
+                    new InputStreamReader(url.openStream(), StandardCharsets.UTF_8));
                 device = parseBufferReader(bufferedReaderNew, model);
             }
             return device;


### PR DESCRIPTION
## Summary

`espresso/src/main/resources/devices.csv` is encoded **UTF-16 LE** (it begins with the BOM `FF FE`), but `MetadataHelper.deviceNameFromCSV` read it with the platform-default charset (UTF-8):

```java
InputStream inputStream = Metadata.class.getResourceAsStream("/devices.csv");
BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream)); // <- no charset
```

Decoded as UTF-8, every other byte of each UTF-16 LE character is an interleaved NUL byte, and the leading BOM lands on the first field. Device-name resolution worked only **by accident** — the NUL bytes happen to be stripped later by `sanitizedString()`. Any change to the sanitization path could silently mis-resolve a device name (which feeds the snapshot's `deviceName` metadata).

## Fix

- Read the bundled `devices.csv` with `StandardCharsets.UTF_16`. The `UTF-16` charset detects the byte order from the BOM **and** strips it, so this addresses both the charset and the BOM in one line.
- Read the remote Google Play fallback (`storage.googleapis.com/.../supported_devices.csv`) explicitly as `UTF_8` (that file is UTF-8) instead of relying on the platform default.

## Verification

Reproduced the parse locally against the actual CSV. With the correct charset the existing assertions are unchanged (the accidental and correct outputs coincide because `sanitizedString()` masked the NUL/BOM), confirming **no regression**:

| Model | Device name |
|-------|-------------|
| `SM-A145F` | Samsung Galaxy A14 |
| `22041216UC` | Redmi Note 11T Pro + |
| `Pixel 7` | Google Pixel 7 |
| `SM-S918B` | Samsung Galaxy S23 Ultra |

Updated `MetadataHelperTest` to document that the assertions reflect the correctly-parsed (UTF-16 decoded, BOM-stripped) device names, and added the two new verified sample lookups above.

Fixes percy/percy-espresso-java#14
Jira: PER-9567

🤖 Generated with [Claude Code](https://claude.com/claude-code)