### PR TITLE
Release 1.0.5-beta.0

### DIFF
--- a/espresso/build.gradle
+++ b/espresso/build.gradle
@@ -10,7 +10,7 @@ android {
         minSdk 24
         targetSdk 33
         versionCode 1
-        versionName "1.0.4-beta.0"
+        versionName "1.0.5-beta.0"
 
         consumerProguardFiles "consumer-rules.pro"
     }
@@ -34,7 +34,7 @@ dependencies {
 
 ext {
     PUBLISH_GROUP_ID = 'io.percy'
-    PUBLISH_VERSION = '1.0.4-beta.0'
+    PUBLISH_VERSION = '1.0.5-beta.0'
     PUBLISH_ARTIFACT_ID = 'espresso-java'
 }
 

--- a/espresso/build.gradle
+++ b/espresso/build.gradle
@@ -10,7 +10,7 @@ android {
         minSdk 24
         targetSdk 33
         versionCode 1
-        versionName "1.0.4"
+        versionName "1.0.4-beta.0"
 
         consumerProguardFiles "consumer-rules.pro"
     }
@@ -34,7 +34,7 @@ dependencies {
 
 ext {
     PUBLISH_GROUP_ID = 'io.percy'
-    PUBLISH_VERSION = '1.0.4'
+    PUBLISH_VERSION = '1.0.4-beta.0'
     PUBLISH_ARTIFACT_ID = 'espresso-java'
 }
 


### PR DESCRIPTION
## Release 1.0.5-beta.0

Cuts the first **beta** of the next release. Maven Central currently has `1.0.3` as the latest; `1.0.4` was already set as the in-code dev version (never published), so this releases the fix as `1.0.5`, betaed as `1.0.5-beta.0`.

### What's included
- **#15 / PER-9567** — `MetadataHelper.deviceNameFromCSV` now reads the bundled `devices.csv` (UTF-16 LE w/ BOM) with `StandardCharsets.UTF_16`, and the remote Google Play fallback explicitly as UTF-8. Fixes device-name resolution that previously worked only by accident.

### Changes
- `espresso/build.gradle`: `PUBLISH_VERSION` and `versionName` → `1.0.5-beta.0`.

### How to publish
Publishing is driven by `.github/workflows/publish.yml`, which triggers on a GitHub **release** (`released`) and runs `publishReleasePublicationToSonatypeRepository … closeAndReleaseSonatypeStagingRepository` on JDK 11 + the Gradle 7.5 wrapper (compatible — unaffected by the Java-21 dependency-submission CI failure).

After merge, cut a GitHub release tagged `v1.0.5-beta.0` to publish `io.percy:espresso-java:1.0.5-beta.0` to Maven Central. (Note: marking it a *pre-release* fires `prereleased`, not `released`; the current workflow only publishes on `released`, so publish as a normal release or adjust the trigger.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)