### PR TITLE
ci(publish): publish on pre-releases + add manual dispatch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,8 +2,13 @@ name: Publish
 
 on:
   release:
-    # We'll run this workflow when a new GitHub release is created
-    types: [released]
+    # Run on full releases AND pre-releases (e.g. *-beta.N). GitHub fires
+    # `released` only for non-prerelease releases and `prereleased` for
+    # pre-releases, so both are needed to publish betas.
+    types: [released, prereleased]
+  # Allow publishing manually from the Actions tab (pick the branch/tag to
+  # build) without having to (re)create a GitHub release.
+  workflow_dispatch:
 
 jobs:
   publish:


### PR DESCRIPTION
## Publish on pre-releases + manual dispatch

`.github/workflows/publish.yml` only triggered on `release: types: [released]`. GitHub fires `released` **only for non-pre-releases**; a pre-release fires `prereleased`. So when `v1.0.5-beta.0` was published as a pre-release, the workflow never ran and nothing reached Maven Central (`io.percy:espresso-java` still tops out at `1.0.3`).

### Change
```yaml
on:
  release:
    types: [released, prereleased]   # was: [released]
  workflow_dispatch:                 # new — manual run from Actions tab
```

- **`prereleased`** — beta/pre-releases now publish too, while staying correctly flagged as pre-releases on GitHub.
- **`workflow_dispatch`** — lets us publish manually from **Actions → Publish → Run workflow** without (re)creating a release.

### Publishing the already-cut `v1.0.5-beta.0` after this merges
The version `1.0.5-beta.0` is already on `main` and the `v1.0.5-beta.0` release/tag already exists — **no version bump or new release PR needed**. Because release/dispatch workflows always use the workflow file from the default branch, merge this **first**, then either:
1. **Actions → Publish → Run workflow** on `main` (simplest), or
2. delete and recreate the `v1.0.5-beta.0` pre-release to re-emit `prereleased`.

Builds on JDK 11 + the Gradle 7.5 wrapper (compatible; unrelated to the Java-21 dependency-submission CI failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)