### PR TITLE
ci: align publish credentials with the other io.percy SDKs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,9 +27,11 @@ jobs:
         # to the Sonatype Central Portal, and auto-releases the deployment.
       - name: Publish to Maven Central
         run: ./gradlew publishToMavenCentral --max-workers 1 --no-configuration-cache
+        # Uses the same four Central Portal secrets as the other io.percy SDKs
+        # (percy-java-selenium / percy-playwright-java): OSSRH_USERNAME +
+        # OSSRH_TOKEN for the Portal user token, and the MAVEN_GPG_* GPG key.
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USERNAME }}
-          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_PASSWORD }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.SIGNING_KEY_ID }}
-          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
-          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_TOKEN }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.MAVEN_GPG_PASSPHRASE }}


### PR DESCRIPTION
## Why

Follow-up to #18 (Central Portal migration). That PR got the *mechanism* right but wired the workflow to credentials that don't match how the rest of the `io.percy` namespace is published.

The other io.percy SDKs already publishing through the Central Portal — [percy-java-selenium](https://github.com/percy/percy-java-selenium/blob/master/.github/workflows/release.yml) and [percy-playwright-java](https://github.com/percy/percy-playwright-java/blob/master/.github/workflows/release.yml) — use these four secrets:

| Purpose | Secret |
|---|---|
| Portal token username | `OSSRH_USERNAME` |
| Portal token password | `OSSRH_TOKEN` |
| GPG signing key (armored) | `MAVEN_GPG_PRIVATE_KEY` |
| GPG key passphrase | `MAVEN_GPG_PASSPHRASE` |

PR #18 instead read `OSSRH_PASSWORD` for the token and the repo's stale 2023 `SIGNING_*` secrets for signing. Two problems:
1. The namespace owner would have to provision this repo differently from every other io.percy repo.
2. The 2023 `SIGNING_KEY` may be an outdated GPG key the Central Portal no longer accepts, failing artifact validation even with a valid token.

> Note: the build systems legitimately differ — the reference repos are Maven (`central-publishing-maven-plugin` + `maven-gpg-plugin`); this repo is Gradle/Android and uses `com.vanniktech.maven.publish`, which is the Gradle-native equivalent. Only the **credential wiring** is being aligned here, not the plugin.

## What

`.github/workflows/publish.yml` — repoint the publish step's env to the four shared secrets:

```yaml
ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.OSSRH_USERNAME }}
ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.OSSRH_TOKEN }}
ORG_GRADLE_PROJECT_signingInMemoryKey:   ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
```

(Dropped `signingInMemoryKeyId` — vanniktech derives it from the key and the reference repos don't use one.)

## Provisioning (for the io.percy namespace owner)

Add the same four secrets this repo as exist on percy-java-selenium / percy-playwright-java — same values. `OSSRH_USERNAME` already exists; `OSSRH_PASSWORD`, `SIGNING_KEY`, `SIGNING_KEY_ID`, `SIGNING_PASSWORD`, and `SONATYPE_STAGING_PROFILE_ID` become unused and can be deleted.

After merge + secrets, trigger `Publish` via `workflow_dispatch` on `main` to ship `1.0.5-beta.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)